### PR TITLE
Renaming repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ########################################## xo
-schema-generator
+airlock
 
 ########################################## Golang
 # Binaries for programs and plugins

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# schema-generator
+# airlock
 Generate JSON Schema from various sources (terraform, helm)

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/massdriver-cloud/schema-generator/pkg/helm"
+	"github.com/massdriver-cloud/airlock/pkg/helm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use: "schema-generator",
+	Use: "airlock",
 }
 
 func Execute() {

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/massdriver-cloud/schema-generator/pkg/terraform"
+	"github.com/massdriver-cloud/airlock/pkg/terraform"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/massdriver-cloud/schema-generator
+module github.com/massdriver-cloud/airlock
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,6 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-*/
 package main
 
-import "github.com/massdriver-cloud/schema-generator/cmd"
+import "github.com/massdriver-cloud/airlock/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/helm/main_test.go
+++ b/pkg/helm/main_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/massdriver-cloud/schema-generator/pkg/helm"
+	"github.com/massdriver-cloud/airlock/pkg/helm"
 )
 
 func TestRun(t *testing.T) {

--- a/pkg/terraform/main_test.go
+++ b/pkg/terraform/main_test.go
@@ -3,7 +3,7 @@ package terraform_test
 import (
 	"testing"
 
-	"github.com/massdriver-cloud/schema-generator/pkg/terraform"
+	"github.com/massdriver-cloud/airlock/pkg/terraform"
 )
 
 func TestRun(t *testing.T) {


### PR DESCRIPTION
Renames repo in code, it was still set to schema-generator causing `go build` to act up.