### PR TITLE
Handle empty arrays by returing null error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
-<img src="images/logo.png" width="600" height="600">
+<img src="images/logo.png" width="400" height="400">
 
 # AIRLOCK
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/massdriver-cloud/airlock)](https://goreportcard.com/report/github.com/massdriver-cloud/airlock)
-[![Build Status](https://travis-ci.com/massdriver-cloud/airlock.svg?branch=master)](https://travis-ci.com/massdriver-cloud/airlock)
-[![Coverage Status](https://coveralls.io/repos/github/massdriver-cloud/airlock/badge.svg?branch=master)](https://coveralls.io/github/massdriver-cloud/airlock?branch=master)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/massdriver-cloud/airlock/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/massdriver-cloud/airlock)](https://github.com/massdriver-cloud/airlock/blob/master/LICENSE)
 
 ## Overview
-Briefly describe what your project does and what it's used for.
-
-## Features
-List the key features of your project. 
+Generate JSON Schema from various sources (terraform, helm) 
 
 ## Getting Started
 

--- a/pkg/helm/helmtoschema.go
+++ b/pkg/helm/helmtoschema.go
@@ -161,7 +161,7 @@ func parseArrayNode(sch *schema.Schema, node *yaml.Node) error {
 	sch.Type = "array"
 
 	if len(node.Content) == 0 {
-		return fmt.Errorf("error: cannot infer element type in array %s. Arrays cannot be empty or the type is ambiguous", sch.Title)
+		return &nullError{}
 	}
 	sch.Items = new(schema.Schema)
 	err := parseValueNode(sch.Items, node.Content[0])

--- a/pkg/helm/testdata/values.yaml
+++ b/pkg/helm/testdata/values.yaml
@@ -18,4 +18,7 @@ array:
   - foo
   - bar
 
+# An empty array should not cause an error
+emptyArray: []
+
 nullValue:


### PR DESCRIPTION
If any empty field is encountered the same warning is printed now:
`Warning: Skipping field imagePullSecrets. Reason: type is indeterminate (null)`
As seen here: https://github.com/cert-manager/cert-manager/blob/release-1.14/deploy/charts/cert-manager/values.yaml#L13