### PR TITLE
declarations schema to bicep

### DIFF
--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -101,9 +101,10 @@ func declareAllowed(sch *schema.Schema, buf *bytes.Buffer) error {
 	return nil
 }
 
+// decorators are in sys namespace. to avoid potential collision with other parameters named "description"
 func declareDescription(sch *schema.Schema, buf *bytes.Buffer) {
 	if sch.Description != "" {
-		buf.WriteString(fmt.Sprintf("@description('%s')\n", sch.Description))
+		buf.WriteString(fmt.Sprintf("@sys.description('%s')\n", sch.Description))
 	}
 }
 
@@ -149,7 +150,7 @@ func declareDefault(name string, sch *schema.Schema, buf *bytes.Buffer) error {
 		}
 
 		if bicepType == "int" {
-			buf.WriteString(fmt.Sprintf("param %s %s = %d\n", name, bicepType, sch.Default))
+			buf.WriteString(fmt.Sprintf("param %s %s = %v\n", name, bicepType, sch.Default))
 		}
 
 		if bicepType == "bool" {

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -101,7 +101,7 @@ func parseArray(arr []interface{}) (string, error) {
 }
 
 func parseObject(obj interface{}) (string, error) {
-	defBytes, err := json.MarshalIndent(obj, "", "    ")
+	defBytes, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		return "", err
 	}
@@ -135,15 +135,18 @@ func writeBicepParam(name string, sch *schema.Schema, buf *bytes.Buffer, bicepTy
 
 func writeAllowedParams(sch *schema.Schema, buf *bytes.Buffer, bicepType string) error {
 	if sch.Enum != nil && len(sch.Enum) > 0 {
-		parsedArray, err := parseArray(sch.Enum)
+		parsedVal, err := parseArray(sch.Enum)
 		if err != nil {
 			return err
 		}
 
 		if bicepType == "object" {
-			obj := renderBicep(sch.Enum, bicepType)
+			parsedVal, err = parseObject(sch.Enum)
+			if err != nil {
+				return err
+			}
 		}
-		buf.WriteString(fmt.Sprintf("@allowed(%v)\n", parsedArray))
+		buf.WriteString(fmt.Sprintf("@allowed(%v)\n", parsedVal))
 	}
 
 	return nil

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -48,6 +48,13 @@ func createBicepParameter(name string, sch *schema.Schema, buf *bytes.Buffer) er
 		}
 	}
 
+	if sch.Description != "" {
+		err = getDescription(sch, buf)
+		if err != nil {
+			return err
+		}
+	}
+
 	buf.WriteString(fmt.Sprintf("param %s %s\n", name, bicepType))
 	return nil
 }
@@ -85,4 +92,9 @@ func getEnums(schemaEnums []interface{}) (string, error) {
 		enums = append(enums, fmt.Sprintf("   '%s'\n", enum))
 	}
 	return fmt.Sprintf("%s", enums), nil
+}
+
+func getDescription(sch *schema.Schema, buf *bytes.Buffer) error {
+	buf.WriteString(fmt.Sprintf("@description('%s')\n", sch.Description))
+	return nil
 }

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -128,8 +128,19 @@ func parseObject(obj interface{}) (string, error) {
 func writeBicepParam(name string, sch *schema.Schema, buf *bytes.Buffer, bicepType string) {
 	defVal := ""
 	if sch.Default != nil {
-		defVal = fmt.Sprintf(" = %v", renderBicep(sch.Default, bicepType))
+		renderedVal := renderBicep(sch.Default, bicepType)
+
+		if bicepType == "object" {
+			renderedVal, _ = parseObject(sch.Default)
+		}
+
+		if bicepType == "array" {
+			renderedVal, _ = parseArray(sch.Default.([]interface{}))
+		}
+
+		defVal = fmt.Sprintf(" = %v", renderedVal)
 	}
+
 	buf.WriteString(fmt.Sprintf("param %s %s%v\n", name, bicepType, defVal))
 }
 

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -42,6 +42,7 @@ func createBicepParameter(name string, sch *schema.Schema, buf *bytes.Buffer) er
 	declareMinValue(sch, buf)
 	declareMaxValue(sch, buf)
 	declareParameter(name, sch, buf)
+	declareDefault(sch, buf)
 	return nil
 }
 
@@ -104,4 +105,34 @@ func declareMaxValue(sch *schema.Schema, buf *bytes.Buffer) {
 	if sch.Maximum != "" {
 		buf.WriteString(fmt.Sprintf("@maxValue(%v)\n", sch.Maximum))
 	}
+}
+
+func declareDefault(sch *schema.Schema, buf *bytes.Buffer) error {
+	if sch.Default != nil {
+		bicepType, err := getBicepType(sch.Type)
+		if err != nil {
+			return err
+		}
+
+		if bicepType == "string" {
+			buf.WriteString(fmt.Sprintf("= '%s'", sch.Default))
+		}
+
+		if bicepType == "int" {
+			buf.WriteString(fmt.Sprintf("= '%d'", sch.Default))
+		}
+
+		if bicepType == "bool" {
+			buf.WriteString(fmt.Sprintf("= '%t'", sch.Default))
+		}
+
+		if bicepType == "array" {
+			buf.WriteString(fmt.Sprintf("= '%v'", sch.Default))
+		}
+
+		if bicepType == "object" {
+			buf.WriteString(fmt.Sprintf("= '%v'", sch.Default))
+		}
+	}
+	return nil
 }

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -218,19 +218,19 @@ func declareDefaultObject(name string, sch *schema.Schema, buf *bytes.Buffer) er
 	}
 
 	r := strings.NewReplacer(`"`, `'`, ",", "")
-	defString := string(defBytes)
-	newDefString := r.Replace(defString)
+	byteToStr := string(defBytes)
+	cleanString := r.Replace(byteToStr)
 
-	splitBytes := strings.Split(newDefString, " ")
-	joinBytes := []string{}
-	for _, d := range splitBytes {
+	splitString := strings.Split(cleanString, " ")
+	joinList := []string{}
+	for _, d := range splitString {
 		if strings.Contains(d, ":") {
 			d = strings.ReplaceAll(d, `'`, "")
 		}
-		joinBytes = append(joinBytes, d)
+		joinList = append(joinList, d)
 	}
-	joinedString := strings.Join(joinBytes, " ")
+	bicepObj := strings.Join(joinList, " ")
 
-	buf.WriteString(fmt.Sprintf("param %s %s = %v\n", name, bicepType, joinedString))
+	buf.WriteString(fmt.Sprintf("param %s %s = %v\n", name, bicepType, bicepObj))
 	return nil
 }

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -41,6 +41,13 @@ func createBicepParameter(name string, sch *schema.Schema, buf *bytes.Buffer) er
 		return err
 	}
 
+	if sch.Enum != nil {
+		err = declareAllowed(sch, buf)
+		if err != nil {
+			return err
+		}
+	}
+
 	buf.WriteString(fmt.Sprintf("param %s %s\n", name, bicepType))
 	return nil
 }
@@ -60,4 +67,22 @@ func getBicepType(schemaType string) (string, error) {
 	default:
 		return "", errors.New("unknown type: " + schemaType)
 	}
+}
+
+func declareAllowed(sch *schema.Schema, buf *bytes.Buffer) error {
+	enums, err := getEnums(sch.Enum)
+	if err != nil {
+		return err
+	}
+
+	buf.WriteString(fmt.Sprintf("@allowed(%s)\n", enums))
+	return nil
+}
+
+func getEnums(schemaEnums []interface{}) (string, error) {
+	enums := []string{"\n"}
+	for _, enum := range schemaEnums {
+		enums = append(enums, fmt.Sprintf("   '%s'\n", enum))
+	}
+	return fmt.Sprintf("%s", enums), nil
 }

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -85,27 +85,17 @@ func renderBicep(val interface{}, prefix string) (string, error) {
 	case "array":
 		assertedVal, asserArrErr := val.([]interface{})
 		if asserArrErr != true {
-			return "", errors.New("failed to assert array type")
+			return "", fmt.Errorf("unable to convert value into array: %v", val)
 		}
 
-		parsedArr, parsArrErr := parseArray(assertedVal, prefix)
-		if parsArrErr != nil {
-			return "", parsArrErr
-		}
-
-		return parsedArr, nil
+		return parseArray(assertedVal, prefix)
 	case "object":
 		assertedVal, asserObjErr := val.(map[string]interface{})
 		if asserObjErr != true {
-			return "", errors.New("failed to assert object type")
+			return "", fmt.Errorf("unable to convert value into object: %v", val)
 		}
 
-		parsedObj, parsObjErr := parseObject(assertedVal, prefix)
-		if parsObjErr != nil {
-			return "", parsObjErr
-		}
-
-		return parsedObj, nil
+		return parseObject(assertedVal, prefix)
 	default:
 		return "", err
 	}

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -102,15 +102,17 @@ func renderBicep(val interface{}, prefix string) string {
 }
 
 func parseArray(arr []interface{}, prefix string) string {
-	parsedArr := "[\n"
 	fmt.Printf("unparsed array: %v\n", arr)
+	parsedArr := "[\n"
 	prefix += "  "
 
 	for _, v := range arr {
-		parsedVal := renderBicep(v, prefix+"  ")
+		parsedVal := renderBicep(v, prefix)
 		parsedArr += fmt.Sprintf("%s%s", prefix, parsedVal) + "\n"
 	}
-	parsedArr += fmt.Sprintf("%s]", prefix[:len(prefix)-2])
+
+	end := len(prefix) / 2
+	parsedArr += fmt.Sprintf("%s]", prefix[:end])
 	fmt.Printf("parsed array: %v\n", parsedArr)
 	return parsedArr
 }
@@ -121,11 +123,12 @@ func parseObject(obj map[string]interface{}, prefix string) string {
 	prefix += "  "
 
 	for k, v := range obj {
-		parsedVal := renderBicep(v, prefix+"  ")
+		parsedVal := renderBicep(v, prefix)
 		parsedObj += fmt.Sprintf("%s%s: %s", prefix, k, parsedVal) + "\n"
 	}
 
-	parsedObj += fmt.Sprintf("%s}", prefix[:len(prefix)-2])
+	end := len(prefix) / 2
+	parsedObj += fmt.Sprintf("%s}", prefix[:end])
 	fmt.Printf("parsed obj: %v\n", parsedObj)
 	return parsedObj
 }

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -43,6 +43,7 @@ func createBicepParameter(name string, sch *schema.Schema, buf *bytes.Buffer) er
 	declareMaxValue(sch, buf)
 	declareMinLength(sch, buf)
 	declareMaxLength(sch, buf)
+	declareSecure(sch, buf)
 	declareParameter(name, sch, buf)
 	return nil
 }
@@ -120,13 +121,13 @@ func declareMaxValue(sch *schema.Schema, buf *bytes.Buffer) {
 
 func declareMinLength(sch *schema.Schema, buf *bytes.Buffer) {
 	if sch.MinLength != nil {
-		buf.WriteString(fmt.Sprintf("@minLength(%d)\n", sch.MinLength))
+		buf.WriteString(fmt.Sprintf("@minLength(%d)\n", *sch.MinLength))
 	}
 }
 
 func declareMaxLength(sch *schema.Schema, buf *bytes.Buffer) {
 	if sch.MaxLength != nil {
-		buf.WriteString(fmt.Sprintf("@maxLength(%d)\n", sch.MaxLength))
+		buf.WriteString(fmt.Sprintf("@maxLength(%d)\n", *sch.MaxLength))
 	}
 }
 

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -93,7 +93,6 @@ func parseArray(arr []interface{}) (string, error) {
 	defString := string(defBytes)
 	r := strings.NewReplacer(`"`, `'`, ",", "")
 
-	// array of objects result?
 	// call converValueToBicep?
 	// handle new line, commas, etc. for arrays
 
@@ -110,7 +109,6 @@ func parseObject(obj interface{}) (string, error) {
 	byteToStr := string(defBytes)
 	cleanString := r.Replace(byteToStr)
 
-	// what if default value in object is a string that has a space?
 	splitString := strings.Split(cleanString, " ")
 	joinList := []string{}
 	for _, d := range splitString {

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -37,17 +37,11 @@ func SchemaToBicep(in io.Reader) ([]byte, error) {
 }
 
 func createBicepParameter(name string, sch *schema.Schema, buf *bytes.Buffer) error {
-	bicepType, err := getBicepType(sch.Type)
-	if err != nil {
-		return err
-	}
-
 	declareAllowed(sch, buf)
 	declareDescription(sch, buf)
 	declareMinValue(sch, buf)
 	declareMaxValue(sch, buf)
-
-	buf.WriteString(fmt.Sprintf("param %s %s\n", name, bicepType))
+	declareParameter(name, sch, buf)
 	return nil
 }
 
@@ -68,6 +62,16 @@ func getBicepType(schemaType string) (string, error) {
 	}
 }
 
+func declareParameter(name string, sch *schema.Schema, buf *bytes.Buffer) error {
+	bicepType, err := getBicepType(sch.Type)
+	if err != nil {
+		return err
+	}
+
+	buf.WriteString(fmt.Sprintf("param %s %s\n", name, bicepType))
+	return nil
+}
+
 func declareAllowed(sch *schema.Schema, buf *bytes.Buffer) error {
 	if sch.Enum != nil && len(sch.Enum) > 0 {
 		enumbytes, err := json.MarshalIndent(sch.Enum, "", "    ")
@@ -78,7 +82,7 @@ func declareAllowed(sch *schema.Schema, buf *bytes.Buffer) error {
 		enumstring := string(enumbytes)
 		r := strings.NewReplacer(`"`, `'`, ",", "")
 
-		buf.WriteString(fmt.Sprintf("@allowed(%s)\n", r.Replace(enumstring)))
+		buf.WriteString(fmt.Sprintf("@allowed(%v)\n", r.Replace(enumstring)))
 	}
 
 	return nil

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -99,9 +99,9 @@ func declareAllowed(sch *schema.Schema, buf *bytes.Buffer) error {
 	return nil
 }
 
-// decorators are in sys namespace. to avoid potential collision with other parameters named "description"
 func declareDescription(sch *schema.Schema, buf *bytes.Buffer) {
 	if sch.Description != "" {
+		// decorators are in sys namespace. to avoid potential collision with other parameters named "description", we use "sys.description" instead of just "description"
 		buf.WriteString(fmt.Sprintf("@sys.description('%s')\n", sch.Description))
 	}
 }

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -44,8 +44,6 @@ func createBicepParameter(name string, sch *schema.Schema, buf *bytes.Buffer) er
 	declareMinLength(sch, buf)
 	declareMaxLength(sch, buf)
 	declareParameter(name, sch, buf)
-	// doing param defaulttest string\n= 'foo' instead
-	// of param defaulttest string = 'foo'\n
 	return nil
 }
 

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -101,22 +101,26 @@ func declareAllowed(sch *schema.Schema, buf *bytes.Buffer) error {
 		cleanString := r.Replace(enumString)
 
 		if bicepType == "object" {
-			splitString := strings.Split(cleanString, " ")
-			joinList := []string{}
-			for _, d := range splitString {
-				if strings.Contains(d, ":") {
-					d = strings.ReplaceAll(d, `'`, "")
-				}
-				joinList = append(joinList, d)
-			}
-			bicepObj := strings.Join(joinList, " ")
-			buf.WriteString(fmt.Sprintf("@allowed(%v)\n", bicepObj))
+			declareAllowedObject(cleanString, sch, buf)
 		} else {
 			buf.WriteString(fmt.Sprintf("@allowed(%v)\n", cleanString))
 		}
 	}
 
 	return nil
+}
+
+func declareAllowedObject(str string, sch *schema.Schema, buf *bytes.Buffer) {
+	splitString := strings.Split(str, " ")
+	joinList := []string{}
+	for _, d := range splitString {
+		if strings.Contains(d, ":") {
+			d = strings.ReplaceAll(d, `'`, "")
+		}
+		joinList = append(joinList, d)
+	}
+	bicepObj := strings.Join(joinList, " ")
+	buf.WriteString(fmt.Sprintf("@allowed(%v)\n", bicepObj))
 }
 
 func declareDescription(sch *schema.Schema, buf *bytes.Buffer) {

--- a/pkg/bicep/schematobicep.go
+++ b/pkg/bicep/schematobicep.go
@@ -101,35 +101,29 @@ func renderBicep(val interface{}, prefix string) string {
 	return ""
 }
 
+var indent string = "  "
+
 func parseArray(arr []interface{}, prefix string) string {
-	fmt.Printf("unparsed array: %v\n", arr)
 	parsedArr := "[\n"
-	prefix += "  "
 
 	for _, v := range arr {
-		parsedVal := renderBicep(v, prefix)
-		parsedArr += fmt.Sprintf("%s%s", prefix, parsedVal) + "\n"
+		parsedVal := renderBicep(v, prefix+indent)
+		parsedArr += fmt.Sprintf("%s%s", prefix+indent, parsedVal) + "\n"
 	}
 
-	end := len(prefix) / 2
-	parsedArr += fmt.Sprintf("%s]", prefix[:end])
-	fmt.Printf("parsed array: %v\n", parsedArr)
+	parsedArr += fmt.Sprintf("%s]", prefix)
 	return parsedArr
 }
 
 func parseObject(obj map[string]interface{}, prefix string) string {
-	fmt.Printf("unparsed obj: %v\n", obj)
 	parsedObj := "{\n"
-	prefix += "  "
 
 	for k, v := range obj {
-		parsedVal := renderBicep(v, prefix)
-		parsedObj += fmt.Sprintf("%s%s: %s", prefix, k, parsedVal) + "\n"
+		parsedVal := renderBicep(v, prefix+indent)
+		parsedObj += fmt.Sprintf("%s%s: %s", prefix+indent, k, parsedVal) + "\n"
 	}
 
-	end := len(prefix) / 2
-	parsedObj += fmt.Sprintf("%s}", prefix[:end])
-	fmt.Printf("parsed obj: %v\n", parsedObj)
+	parsedObj += fmt.Sprintf("%s}", prefix)
 	return parsedObj
 }
 

--- a/pkg/bicep/schematobicep_test.go
+++ b/pkg/bicep/schematobicep_test.go
@@ -35,7 +35,7 @@ func TestSchemaToBicep(t *testing.T) {
 			}
 
 			if string(got) != string(want) {
-				t.Fatalf("got %q want %q", string(got), string(want))
+				t.Fatalf("\ngot: %q\n want: %q", string(got), string(want))
 			}
 		})
 	}

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -81,5 +81,19 @@ param defaultobjecttest object = {
   bar: 'baz'
   foo: 5
 }
+param defaultspaceobjecttest object = {
+  foo: 'bar baz'
+  lorem: 'ipsum'
+}
+param defaultarrayobjecttest array = [
+  {
+    bar: 'baz'
+    foo: 5
+  }
+  {
+    bar: 'qux'
+    foo: 10
+  }
+]
 @secure()
 param securestringtest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -95,5 +95,33 @@ param defaultarrayobjecttest array = [
     foo: 10
   }
 ]
+param defaultnestedarraytest array = [
+  [
+    [
+      'foo'
+    ]
+    [
+      'bar'
+    ]
+  ]
+  [
+    [
+      'baz'
+    ]
+    [
+      'qux'
+    ]
+  ]
+]
+param defaultnestedobjecttest object = {
+  foo: {
+    bar: {
+      baz: 'qux'
+    }
+  }
+  quid: {
+    pro: 'quo'
+  }
+}
 @secure()
 param securestringtest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -69,8 +69,8 @@ param defaultarraytest array = [
     'bar'
 ]
 param defaultobjecttest object = {
-    foo: 'baz'
-    bar: 5
+    bar: 'baz'
+    foo: 5
 }
 @secure()
 param securestringtest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -10,3 +10,5 @@ param nestedtest object
     'bar'
 ])
 param enumtest string
+@description('This is a description')
+param descriptiontest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -42,12 +42,12 @@ param enumtestarrays array
 param enumobjecttest object
 @sys.description('This is a description')
 param descriptiontest string
+@sys.description('This is a new description')
 @allowed([
   'foo'
   'bar'
   'baz'
 ])
-@sys.description('This is a new description')
 param descriptionenumtest string
 @minValue(5)
 param minvaluetest int

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -12,3 +12,17 @@ param nestedtest object
 param enumtest string
 @description('This is a description')
 param descriptiontest string
+@allowed([
+    'foo'
+    'bar'
+    'baz'
+])
+@description('This is a new description')
+param descriptionenumtest string
+@minValue(5)
+param minvaluetest int
+@maxValue(10)
+param maxvaluetest int
+@minValue(5)
+@maxValue(10)
+param minmaxvaluetest int

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -6,46 +6,46 @@ param arraytest array
 param objecttest object
 param nestedtest object
 @allowed([
-    'foo'
-    'bar'
+  'foo'
+  'bar'
 ])
 param enumtest string
 @allowed([
-    1
-    2
+  1
+  2
 ])
 param enumtestints int
 @allowed([
-    true
-    false
+  true
+  false
 ])
 param enumtestbools bool
 @allowed([
-    [
-        'foo'
-        'bar'
-    ]
-    [
-        'baz'
-        'qux'
-    ]
+  [
+    'foo'
+    'bar'
+  ]
+  [
+    'baz'
+    'qux'
+  ]
 ])
 param enumtestarrays array
 @allowed([
-    {
-        foo: 'bar'
-    }
-    {
-        baz: 'qux'
-    }
+  {
+    foo: 'bar'
+  }
+  {
+    baz: 'qux'
+  }
 ])
 param enumobjecttest object
 @sys.description('This is a description')
 param descriptiontest string
 @allowed([
-    'foo'
-    'bar'
-    'baz'
+  'foo'
+  'bar'
+  'baz'
 ])
 @sys.description('This is a new description')
 param descriptionenumtest string
@@ -74,12 +74,12 @@ param defaultstringtest string = 'foo'
 param defaultintegertest int = 5
 param defaultbooltest bool = true
 param defaultarraytest array = [
-    'foo'
-    'bar'
+  'foo'
+  'bar'
 ]
 param defaultobjecttest object = {
-    bar: 'baz'
-    foo: 5
+  bar: 'baz'
+  foo: 5
 }
 @secure()
 param securestringtest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -68,6 +68,10 @@ param defaultarraytest array = [
     'foo'
     'bar'
 ]
+param defaultobjecttest object = {
+    foo: 'baz'
+    bar: 5
+}
 @secure()
 param securestringtest string
 @secure()

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -57,3 +57,5 @@ param minmaxlengthtest string
 param defaulttest string = 'foo'
 param defaultintegertest int = 5
 param defaultbooltest bool = true
+@secure()
+param securetest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -48,14 +48,27 @@ param maxvaluetest int
 @maxValue(10)
 param minmaxvaluetest int
 @minLength(5)
-param minlengthtest string
+param minlengthstringtest string
 @maxLength(10)
-param maxlengthtest string
+param maxlengthstringtest string
 @minLength(5)
 @maxLength(10)
-param minmaxlengthtest string
-param defaulttest string = 'foo'
+param minmaxlengthstringtest string
+@minLength(2)
+param minlengtharraytest array
+@maxLength(5)
+param maxlengtharraytest array
+@minLength(2)
+@maxLength(5)
+param minmaxlengtharraytest array
+param defaultstringtest string = 'foo'
 param defaultintegertest int = 5
 param defaultbooltest bool = true
+param defaultarraytest array = [
+    'foo'
+    'bar'
+]
 @secure()
-param securetest string
+param securestringtest string
+@secure()
+param secureobjecttest object

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -31,14 +31,14 @@ param enumtestbools bool
     ]
 ])
 param enumtestarrays array
-@description('This is a description')
+@sys.description('This is a description')
 param descriptiontest string
 @allowed([
     'foo'
     'bar'
     'baz'
 ])
-@description('This is a new description')
+@sys.description('This is a new description')
 param descriptionenumtest string
 @minValue(5)
 param minvaluetest int
@@ -56,3 +56,4 @@ param maxlengthtest string
 param minmaxlengthtest string
 param defaulttest string = 'foo'
 param defaultintegertest int = 5
+param defaultbooltest bool = true

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -10,6 +10,27 @@ param nestedtest object
     'bar'
 ])
 param enumtest string
+@allowed([
+    1
+    2
+])
+param enumtestints int
+@allowed([
+    true
+    false
+])
+param enumtestbools bool
+@allowed([
+    [
+        'foo'
+        'bar'
+    ]
+    [
+        'baz'
+        'qux'
+    ]
+])
+param enumtestarrays array
 @description('This is a description')
 param descriptiontest string
 @allowed([
@@ -26,3 +47,4 @@ param maxvaluetest int
 @minValue(5)
 @maxValue(10)
 param minmaxvaluetest int
+param defaulttest string = 'foo'

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -83,5 +83,3 @@ param defaultobjecttest object = {
 }
 @secure()
 param securestringtest string
-@secure()
-param secureobjecttest object

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -5,3 +5,8 @@ param booltest bool
 param arraytest array
 param objecttest object
 param nestedtest object
+@allowed([
+    'foo'
+    'bar'
+])
+param enumtest string

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -31,6 +31,15 @@ param enumtestbools bool
     ]
 ])
 param enumtestarrays array
+@allowed([
+    {
+        foo: 'bar'
+    }
+    {
+        baz: 'qux'
+    }
+])
+param enumobjecttest object
 @sys.description('This is a description')
 param descriptiontest string
 @allowed([

--- a/pkg/bicep/testdata/simple.bicep
+++ b/pkg/bicep/testdata/simple.bicep
@@ -47,4 +47,12 @@ param maxvaluetest int
 @minValue(5)
 @maxValue(10)
 param minmaxvaluetest int
+@minLength(5)
+param minlengthtest string
+@maxLength(10)
+param maxlengthtest string
+@minLength(5)
+@maxLength(10)
+param minmaxlengthtest string
 param defaulttest string = 'foo'
+param defaultintegertest int = 5

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -124,9 +124,26 @@
       "minimum": 5,
       "maximum": 10
     },
+    "minlengthtest": {
+      "type": "string",
+      "minLength": 5
+    },
+    "maxlengthtest": {
+      "type": "string",
+      "maxLength": 10
+    },
+    "minmaxlengthtest": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 10
+    },
     "defaulttest": {
       "type": "string",
       "default": "foo"
+    },
+    "defaultintegertest": {
+      "type": "integer",
+      "default": 5
     }
   }
 }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -124,20 +124,42 @@
       "minimum": 5,
       "maximum": 10
     },
-    "minlengthtest": {
+    "minlengthstringtest": {
       "type": "string",
       "minLength": 5
     },
-    "maxlengthtest": {
+    "maxlengthstringtest": {
       "type": "string",
       "maxLength": 10
     },
-    "minmaxlengthtest": {
+    "minmaxlengthstringtest": {
       "type": "string",
       "minLength": 5,
       "maxLength": 10
     },
-    "defaulttest": {
+    "minlengtharraytest": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 2
+    },
+    "maxlengtharraytest": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 5
+    },
+    "minmaxlengtharraytest": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 2,
+      "maxItems": 5
+    },
+    "defaultstringtest": {
       "type": "string",
       "default": "foo"
     },
@@ -149,8 +171,22 @@
       "type": "boolean",
       "default": true
     },
-    "securetest": {
+    "defaultarraytest": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "foo",
+        "bar"
+      ]
+    },
+    "securestringtest": {
       "type": "string",
+      "format": "password"
+    },
+    "secureobjecttest": {
+      "type": "object",
       "format": "password"
     }
   }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -98,6 +98,17 @@
         ]
       ]
     },
+    "enumobjecttest": {
+      "type": "object",
+      "enum": [
+        {
+          "foo": "bar"
+        },
+        {
+          "baz": "qux"
+        }
+      ]
+    },
     "descriptiontest": {
       "type": "string",
       "description": "This is a description"

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -214,10 +214,6 @@
     "securestringtest": {
       "type": "string",
       "format": "password"
-    },
-    "secureobjecttest": {
-      "type": "object",
-      "format": "password"
     }
   }
 }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -184,20 +184,20 @@
     "defaultobjecttest": {
       "type": "object",
       "required": [
-        "foo",
-        "bar"
+        "bar",
+        "foo"
       ],
       "properties": {
-        "foo": {
+        "bar": {
           "type": "string"
         },
-        "bar": {
+        "foo": {
           "type": "integer"
         }
       },
       "default": {
-        "foo": "baz",
-        "bar": 5
+        "bar": "baz",
+        "foo": 5
       }
     },
     "securestringtest": {

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -144,6 +144,10 @@
     "defaultintegertest": {
       "type": "integer",
       "default": 5
+    },
+    "defaultbooltest": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -71,6 +71,28 @@
     "descriptiontest": {
       "type": "string",
       "description": "This is a description"
+    },
+    "descriptionenumtest": {
+      "type": "string",
+      "description": "This is a new description",
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
+      ]
+    },
+    "minvaluetest": {
+      "type": "integer",
+      "minimum": 5
+    },
+    "maxvaluetest": {
+      "type": "integer",
+      "maximum": 10
+    },
+    "minmaxvaluetest": {
+      "type": "integer",
+      "minimum": 5,
+      "maximum": 10
     }
   }
 }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -181,6 +181,25 @@
         "bar"
       ]
     },
+    "defaultobjecttest": {
+      "type": "object",
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      },
+      "default": {
+        "foo": "baz",
+        "bar": 5
+      }
+    },
     "securestringtest": {
       "type": "string",
       "format": "password"

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -148,6 +148,10 @@
     "defaultbooltest": {
       "type": "boolean",
       "default": true
+    },
+    "securetest": {
+      "type": "string",
+      "format": "password"
     }
   }
 }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -68,6 +68,36 @@
         "bar"
       ]
     },
+    "enumtestints": {
+      "type": "integer",
+      "enum": [
+        1,
+        2
+      ]
+    },
+    "enumtestbools": {
+      "type": "boolean",
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "enumtestarrays": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "enum": [
+        [
+          "foo",
+          "bar"
+        ],
+        [
+          "baz",
+          "qux"
+        ]
+      ]
+    },
     "descriptiontest": {
       "type": "string",
       "description": "This is a description"
@@ -93,7 +123,10 @@
       "type": "integer",
       "minimum": 5,
       "maximum": 10
+    },
+    "defaulttest": {
+      "type": "string",
+      "default": "foo"
     }
   }
 }
-

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -102,10 +102,12 @@
       "type": "object",
       "enum": [
         {
-          "foo": "bar"
+          "foo": "bar",
+          "type": "string"
         },
         {
-          "baz": "qux"
+          "baz": "qux",
+          "type": "string"
         }
       ]
     },

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -1,58 +1,73 @@
 {
-    "required": [
-        "stringtest",
-        "integertest",
-        "numbertest",
-        "booltest",
-        "arraytest",
-        "objecttest",
-        "nestedtest"
-    ],
-    "properties": {
-        "stringtest": {
-            "type": "string"
+  "required": [
+    "stringtest",
+    "integertest",
+    "numbertest",
+    "booltest",
+    "arraytest",
+    "objecttest",
+    "nestedtest",
+    "enumtest"
+  ],
+  "properties": {
+    "stringtest": {
+      "type": "string"
+    },
+    "integertest": {
+      "type": "integer"
+    },
+    "numbertest": {
+      "type": "number"
+    },
+    "booltest": {
+      "type": "boolean"
+    },
+    "arraytest": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "objecttest": {
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "string"
         },
-        "integertest": {
-            "type": "integer"
-        },
-        "numbertest": {
-            "type": "number"
-        },
-        "booltest": {
-            "type": "boolean"
-        },
-        "arraytest": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
-        },
-        "objecttest": {
-            "type": "object",
-            "required": ["foo"],
-            "properties": {
-                "foo": {
-                    "type": "string"
-                },
-                "bar": {
-                    "type": "integer"
-                }
-            }
-        },
-        "nestedtest": {
-            "type": "object",
-            "required": ["top"],
-            "properties": {
-                "top": {
-                    "type": "object",
-                    "required": ["nested"],
-                    "properties": {
-                        "nested": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+        "bar": {
+          "type": "integer"
         }
+      }
+    },
+    "nestedtest": {
+      "type": "object",
+      "required": [
+        "top"
+      ],
+      "properties": {
+        "top": {
+          "type": "object",
+          "required": [
+            "nested"
+          ],
+          "properties": {
+            "nested": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "enumtest": {
+      "type": "string",
+      "enum": [
+        "foo",
+        "bar"
+      ]
     }
+  }
 }
+

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -258,6 +258,85 @@
         }
       ]
     },
+    "defaultnestedarraytest": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "default": [
+        [
+          [
+            "foo"
+          ],
+          [
+            "bar"
+          ]
+        ],
+        [
+          [
+            "baz"
+          ],
+          [
+            "qux"
+          ]
+        ]
+      ]
+    },
+    "defaultnestedobjecttest": {
+      "type": "object",
+      "required": [
+        "foo",
+        "quid"
+      ],
+      "properties": {
+        "foo": {
+          "type": "object",
+          "required": [
+            "bar"
+          ],
+          "properties": {
+            "bar": {
+              "type": "object",
+              "required": [
+                "baz"
+              ],
+              "properties": {
+                "baz": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "quid": {
+          "type": "object",
+          "required": [
+            "pro"
+          ],
+          "properties": {
+            "pro": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "default": {
+        "foo": {
+          "bar": {
+            "baz": "qux"
+          }
+        },
+        "quid": {
+          "pro": "quo"
+        }
+      }
+    },
     "securestringtest": {
       "type": "string",
       "format": "password"

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -67,6 +67,10 @@
         "foo",
         "bar"
       ]
+    },
+    "descriptiontest": {
+      "type": "string",
+      "description": "This is a description"
     }
   }
 }

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -211,6 +211,53 @@
         "foo": 5
       }
     },
+    "defaultspaceobjecttest": {
+      "type": "object",
+      "required": [
+        "foo",
+        "lorem"
+      ],
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "lorem": {
+          "type": "string"
+        }
+      },
+      "default": {
+        "foo": "bar baz",
+        "lorem": "ipsum"
+      }
+    },
+    "defaultarrayobjecttest": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "properties": {
+          "bar": {
+            "type": "string"
+          },
+          "foo": {
+            "type": "integer"
+          }
+        }
+      },
+      "default": [
+        {
+          "bar": "baz",
+          "foo": 5
+        },
+        {
+          "bar": "qux",
+          "foo": 10
+        }
+      ]
+    },
     "securestringtest": {
       "type": "string",
       "format": "password"

--- a/pkg/bicep/testdata/simple.json
+++ b/pkg/bicep/testdata/simple.json
@@ -102,12 +102,10 @@
       "type": "object",
       "enum": [
         {
-          "foo": "bar",
-          "type": "string"
+          "foo": "bar"
         },
         {
-          "baz": "qux",
-          "type": "string"
+          "baz": "qux"
         }
       ]
     },

--- a/pkg/bicep/testdata/template.bicep
+++ b/pkg/bicep/testdata/template.bicep
@@ -2,7 +2,7 @@
 @minLength(2)
 @maxLength(20)
 @allowed(['foo','bar'])
-param testString string = "foo"
+param testString string = 'foo'
 
 @minValue(0)
 @maxValue(10)
@@ -31,11 +31,11 @@ param testObject object = {
 
 param testArrayObject array = [
     {
-        foo: 'bar',
+        foo: 'bar'
         num: 10
-    },
+    }
     {
-        foo: 'baz',
+        foo: 'baz'
         num: 2
     }
 ]
@@ -49,5 +49,6 @@ param testSecureString string
 @secure()
 param testSecureObject object
 
-resource whatever 'foobar' = {
+resource whatever 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+    name: 'myVnet'
 }


### PR DESCRIPTION
List of decorators to support:

allows (enums):
- [x] strings
- [x] ints
- [x] bools
- [x] arrays
- [x] objects

defaults:
- [x] strings
- [x] ints
- [x] bools
- [x] arrays
- [x] objects

others:
- [x] description
- [x] max length (maximum string len)
- [x] max length (array)
- [x] max value (maximum int)
- [x] min length (minimum string len)
- [x] min length (array)
- [x] min value (minimum int)
- [x] ~metadata (custom key/value props)~
- [x] secure strings
- [x] secure objects